### PR TITLE
[bugfix] disable htree for /lost+found

### DIFF
--- a/lib/ext2fs/openfs.c
+++ b/lib/ext2fs/openfs.c
@@ -85,12 +85,49 @@ blk_t ext2fs_descriptor_block_loc(ext2_filsys fs, blk_t group_block, dgrp_t i)
 	return ext2fs_descriptor_block_loc2(fs, group_block, i);
 }
 
+static errcode_t disable_htree_for_lost_found(ext2_filsys fs) {
+    char *name = "lost+found";
+    errcode_t ret;
+    ext2_ino_t ino;
+    ret = ext2fs_lookup(fs, EXT2_ROOT_INO, name, strlen(name), 0, &ino);
+    if (ret) {
+        return ret;
+    }
+    struct ext2_inode inode;
+    ret = ext2fs_read_inode(fs, ino, &inode);
+    if (ret) {
+        return ret;
+    }
+    if (inode.i_flags & EXT2_INDEX_FL) {
+        inode.i_flags &= ~EXT2_INDEX_FL;
+        ret = ext2fs_write_inode(fs, ino, &inode);
+        if (ret) {
+            return ret;
+        }
+    }
+    return 0;
+}
+
 errcode_t ext2fs_open(const char *name, int flags, int superblock,
 		      unsigned int block_size, io_manager manager,
 		      ext2_filsys *ret_fs)
 {
-	return ext2fs_open2(name, 0, flags, superblock, block_size,
+	errcode_t ret = ext2fs_open2(name, 0, flags, superblock, block_size,
 			    manager, ret_fs);
+    if (ret) {
+        return ret;
+    }
+    ret = ext2fs_read_bitmaps(*ret_fs);
+    if (ret) {
+        ext2fs_close(*ret_fs);
+        return ret;
+    }
+    ret = disable_htree_for_lost_found(*ret_fs);
+    if (ret) {
+        ext2fs_close(*ret_fs);
+        return ret;
+    }
+    return 0;
 }
 
 static void block_sha_map_free_entry(void *data)


### PR DESCRIPTION
e2fsck reports HTREE directory errors on converted extfs images:
```
sudo e2fsck -nfv /dev/sda
...
Pass 2: Checking directory structure
Problem in HTREE directory inode 11: block #2 not referenced
Invalid HTREE directory inode 11 (/lost+found).  Clear HTree index?
```

The root cause is in `photon::fs::make_extfs() -> mkdir_lost_found()`, which calls ext2fs_expand_dir() twice to ensure at least 2 blocks:
```
for (int i = 0; i < 2; i++) {
    ret = ext2fs_expand_dir(fs, ino);
}
```

The first call creates a hash-indexed (HTREE) directory. However, ext2fs_expand_dir() is not designed to be called again on an HTREE directory -- HTREE growth uses a separate implementation path. The second call corrupts the directory structure by failing to properly extend the hash tree.

Fix this by disabling HTREE for the lost+found directory when opening the filesystem.